### PR TITLE
Actualización de la ruta de archivo de WooCommerce para consistencia del plugin

### DIFF
--- a/core/functions/functions.php
+++ b/core/functions/functions.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Utilities\OrderUtil;
-require_once ABSPATH . 'wp-content/plugins/woocommerce/includes/admin/wc-admin-functions.php';
+require_once WP_PLUGIN_DIR . '/woocommerce/includes/admin/wc-admin-functions.php';
 
 /**
  * SEUR Debug notice


### PR DESCRIPTION
Se ajustó la forma en que se incluyen las funciones de administración de WooCommerce al cambiar la ruta para usar la constante del directorio de plugins. Esto mejora la compatibilidad y garantiza que las funciones se carguen correctamente, independientemente de la estructura de la instalación de WordPress. Enfatizar la consistencia mejorará el mantenimiento y reducirá posibles problemas de rutas en diferentes entornos.

Corrige https://github.com/SEUROficial/Wocommerce/issues/11