### PR TITLE
Compatibilidad PHP 8.2 + bug en cadena

### DIFF
--- a/classes/class-seur-global.php
+++ b/classes/class-seur-global.php
@@ -12,6 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Seur_Global {
 
+    /**
+     * @var WC_Logger
+     */
+    private $log;
+
 	public function __construct() {
 		$this->log = new WC_Logger();
 	}
@@ -946,7 +951,7 @@ class Seur_Global {
 
     public function is_seur_order($order_id) {
         global $wpdb;
-        $query = "SELECT distinct o.order_id 
+        $query = "SELECT distinct o.order_id
             FROM {$wpdb->prefix}woocommerce_order_items o
             inner join {$wpdb->prefix}woocommerce_order_itemmeta om on om.order_item_id = o.order_item_id
             where om.meta_key = 'method_id' and (om.meta_value like '%seur%')
@@ -956,7 +961,7 @@ class Seur_Global {
 
     public function is_seur_local_method($custom_rate_id) {
         global $wpdb;
-        $query = "SELECT ID 
+        $query = "SELECT ID
             FROM {$wpdb->prefix}seur_custom_rates
             where rate like '%2SHOP' and ID = ".$custom_rate_id;
         return $wpdb->get_results( $query );

--- a/core/functions/functions.php
+++ b/core/functions/functions.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Utilities\OrderUtil;
-require_once ABSPATH . 'wp-content/plugins/woocommerce/includes/admin/wc-admin-functions.php';
+require_once WP_PLUGIN_DIR . '/woocommerce/includes/admin/wc-admin-functions.php';
 
 /**
  * SEUR Debug notice

--- a/core/pages/seur-settings.php
+++ b/core/pages/seur-settings.php
@@ -41,7 +41,7 @@ function seur_settings() {
 				<?php
 				settings_fields( 'seur-user-settings-section' );
 				do_settings_sections( 'seur-user-settings-options' );
-				wp_kses_post( _e( '(<sup>*</sup>) This data is provided by SEUR', 'seur' ) );
+				echo wp_kses_post( __( '(<sup>*</sup>) This data is provided by SEUR', 'seur' ) );
 			} else {
 				?>
 				<p>

--- a/core/woocommerce/includes/class-seur_local_shipping_method.php
+++ b/core/woocommerce/includes/class-seur_local_shipping_method.php
@@ -16,7 +16,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Seur_Local_Shipping_Method extends WC_Shipping_Method {
 
-	/**
+    /**
+     * @var WC_Logger
+     */
+    private $log;
+
+    /**
 	 * Constructor. The instance ID is passed to this.
 	 *
 	 * @param int $instance_id Intance ID.
@@ -391,11 +396,11 @@ function seur_after_seur_2shop_shipping_rate( $method, $index ) {
                         return this.html_element;
                     }
                 };
-          
+
                 var SeurPickupsLocs = [" .
                     wp_kses( $print_js, ['br' => [],'p' => [],'strong' => []] ) . "
                 ];
-			
+
 				var maplace = new Maplace();
 				maplace.AddControl('seurdropdown', html_seurdropdown);
 				maplace.Load({

--- a/core/woocommerce/includes/class-wc-shipping-seur.php
+++ b/core/woocommerce/includes/class-wc-shipping-seur.php
@@ -18,6 +18,136 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Shipping_SEUR extends WC_Shipping_Method {
 
+    /**
+     * @var WC_Logger
+     */
+    private $log;
+
+    /**
+     * @var bool
+     */
+    public $debug;
+
+    /**
+     * @var string
+     */
+    public $title;
+
+    /**
+     * @var string
+     */
+    public $simple_advanced;
+
+    /**
+     * @var string
+     */
+    public $user_id;
+
+    /**
+     * @var string
+     */
+    public $password;
+
+    /**
+     * @var string
+     */
+    public $access_key;
+
+    /**
+     * @var string
+     */
+    public $shipper_number;
+
+    /**
+     * @var bool
+     */
+    public $origin_addressline;
+
+    /**
+     * @var string
+     */
+    public $origin_city;
+
+    /**
+     * @var string
+     */
+    public $origin_postcode;
+
+    /**
+     * @var string
+     */
+    public $origin_country_state;
+
+    /**
+     * @var string
+     */
+    public $pickup;
+
+    /**
+     * @var bool
+     */
+    public $residential;
+
+    /**
+     * @var string
+     */
+    public $offer_rates;
+
+    /**
+     * @var string
+     */
+    public $fallback;
+
+    /**
+     * @var string
+     */
+    public $packing_method;
+
+    /**
+     * @var array
+     */
+    public $seur_packaging;
+
+    /**
+     * @var array
+     */
+    public $custom_services;
+
+    /**
+     * @var array
+     */
+    public $boxes;
+
+    /**
+     * @var bool
+     */
+    public $insuredvalue;
+
+    /**
+     * @var string|bool
+     */
+    public $units;
+
+    /**
+     * @var string
+     */
+    public $weight_unit;
+
+    /**
+     * @var string
+     */
+    public $dim_unit;
+
+    /**
+     * @var string
+     */
+    public $origin_country;
+
+    /**
+     * @var string
+     */
+    public $origin_state;
+
 	/**
 	 * __construct function.
 	 *


### PR DESCRIPTION
Se ha declarado de forma explícita las propiedades de clase en Seur_Global y WC_Shipping_SEUR para evitar la creación dinámica (obsoleta en PHP 8.2), que provocaba warnings en el log de WordPress.

Además se ha corregido una cadena en la página de ajustes que no se estaba mostrando correctamente.